### PR TITLE
LonStringValue fix

### DIFF
--- a/livesettings/values.py
+++ b/livesettings/values.py
@@ -821,8 +821,8 @@ class LongStringValue(Value):
     def make_setting(self, db_value, language_code=None):
         log.debug('new long setting %s.%s', self.group.key, self.key)
         key = self.key
-        if self.localized and language_code:
-            key = self.key + '_' + format_setting_name(language_code)
+        if self.localized:
+            key += '_' + format_setting_name(language_code or get_language())
         return LongSetting(group=self.group.key, key=key, value=db_value)
 
     def to_python(self, value):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-livesettings3',
-    version='1.4.20',
+    version='1.4.21',
     description="Python 3 port of django-livesettings",
     long_description="""Python 3 version of django live settings. It provides the ability to configure settings via an admin interface, rather than by editing "settings.py". Documentation avaiable at Github.""",
     author='Kunal Deo',


### PR DESCRIPTION
Internationalization was not correctly managed when not explicitly set in values.py.
I have just harmonized according other types.