### PR TITLE
Update usage of deprecated translation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Create `config.py` within your app directory where your `models.py` is located. 
 `config.py`
 
 ```python
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from livesettings.functions import config_register
 from livesettings.values import ConfigurationGroup, PositiveIntegerValue, MultipleStringValue
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,7 +15,7 @@ We will create the following :file:`config.py`::
 
     from livesettings.functions import config_register
     from livesettings.values import ConfigurationGroup, PositiveIntegerValue, MultipleStringValue
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
     # First, setup a grup to hold all our possible configs
     MYAPP_GROUP = ConfigurationGroup(

--- a/livesettings/functions.py
+++ b/livesettings/functions.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 from livesettings import values
 from livesettings.models import SettingNotSet
 from livesettings.utils import is_string_like
@@ -255,7 +255,7 @@ def config_choice_values(group, key, skip_missing=True, translate=False):
             raise SettingNotSet('%s.%s' % (group, key))
 
     if translate:
-        choices = [(k, ugettext(v)) for k, v in choices]
+        choices = [(k, gettext(v)) for k, v in choices]
 
     return choices
 

--- a/livesettings/models.py
+++ b/livesettings/models.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from django.db.models import loading as apps
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from keyedcache import cache_key, cache_get, cache_set, NotCachedError
 from keyedcache.models import CachedObjectMixin
 from livesettings.overrides import get_overrides

--- a/livesettings/values.py
+++ b/livesettings/values.py
@@ -25,7 +25,7 @@ from django.core.files import storage
 from django.db import connection, DatabaseError
 from django.utils.encoding import smart_str
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext, ugettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _
 from django.utils.translation import get_language as _get_language
 from livesettings.models import find_setting, LongSetting, Setting, SettingNotSet
 from livesettings.overrides import get_overrides

--- a/test-project/localsite/config.py
+++ b/test-project/localsite/config.py
@@ -1,6 +1,6 @@
 """Examples for livesettings"""
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from livesettings.functions import config_register, config_register_list, config_get
 from livesettings.values import *
 
@@ -158,7 +158,7 @@ config_register_list(
 # and can be completely removed. That only removes some one conditional group and its
 # choice in MY_CONDITIONAL_SWITCHES.
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # add a new choice to main choises where this module can be enabled
 MY_CONDITIONAL_SWITCHES = config_get('MY_CONDITIONAL', 'MODULES')


### PR DESCRIPTION
Functions `ugettext` and `ugettext_lazy` from `django.utils.translation` became deprecated in [Django 3.0](https://docs.djangoproject.com/en/3.0/releases/3.0/#id3) and were removed in [Django 4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0).
This PR replaces deprecated functions with their up-to-date aliases `gettext` and `gettext_lazy`.